### PR TITLE
Adding requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+mtgsdk==1.2.0
+requests==2.11.1
+six==1.10.0
+slackclient==1.0.1
+websocket-client==0.37.0


### PR DESCRIPTION
Adding dependency list for management with `virtualenv`.

Once `virtualenv` is installed, create the `venv/` folder with `virtualenv venv`, then run `./venv/bin/activate` to enter the environment. Once active, run `pip install -r requirements.txt` to install the listed dependencies.
